### PR TITLE
pass id and default params to node-view-factory

### DIFF
--- a/src/lacij/edit/graph.clj
+++ b/src/lacij/edit/graph.clj
@@ -21,7 +21,7 @@
   [id shape x y node-styles style node-attrs attrs node-view-factory]
   (if (nil? node-view-factory)
     (create-nodeview id shape x y (merge node-styles style) (merge node-attrs attrs))
-    (if-let [node-view (node-view-factory shape x y style attrs)]
+    (if-let [node-view (node-view-factory id shape x y (merge node-styles style) (merge node-attrs attrs))]
       node-view
       (create-nodeview id shape x y
                        (merge node-styles style)


### PR DESCRIPTION
Hi,

nice library! I'd like to use a `node-view-factory` but noticed that the `id` ain't passed to that factory which makes the extension point a bit less useful. 
Unfortunately this would be a breaking change, but maybe we can agree that it was broken beforehand :)

Cheers,
Gerrit
